### PR TITLE
[PLAT-643] Remove checking out the git repo, as this is not needed

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,11 +16,6 @@ jobs:
   pr-title-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Install Node JS
         uses: actions/setup-node@v2
 


### PR DESCRIPTION
In cases, where the base repo is also in Javascript, there could be conflicts between the npm dependencies. However, those are completely irrelevant. 