### PR TITLE
[ONC-479] handle quotes properly

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -27,5 +27,7 @@ jobs:
 
       - name: Lint the PR title
         run: |
-          echo "${{ github.event.pull_request.title }}" |\
-            npx commitlint --config ./node_modules/commitlint-config/.commitlint.config.js
+          (cat <<EOF
+          ${{ github.event.pull_request.title }}
+          EOF
+          ) | npx commitlint --config ./node_modules/commitlint-config/.commitlint.config.js


### PR DESCRIPTION
I believe revert commit messages were failing the PR title lint because it wasn't handling quotation marks. See example error message: https://github.com/taptapsend/consul/actions/runs/7575850306/job/20633388600?pr=2010
```
Run echo "Revert "[TTS-6020] staging: temporarily allow up to 500% FX rate change (#1993)"" |\
/home/runner/work/_temp/d81093f7-93[5](https://github.com/taptapsend/consul/actions/runs/7575460006/job/20632112545?pr=2010#step:5:6)2-40f8-b26f-9f208c444ef2.sh: line 1: syntax error near unexpected token `('
```

Use `EOF` instead of `"` so we can handle quotes in the PR title.

Weirdly it now **always** passes when the first word is "revert", even if there's no Jira ticket. I think that must be a special recognized keyword in the commitlint library.

[TTS-6020]: https://taptapsend.atlassian.net/browse/TTS-6020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ