### PR TITLE
PLAT-3773 fix: add pull-requests write permission to workflow

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,6 +1,6 @@
 on:
   workflow_call:
-  
+
   pull_request:
     types:
       - opened
@@ -11,6 +11,9 @@ on:
       - 'master'
       - 'release'
       - 'main'
+
+permissions:
+  pull-requests: write
 
 jobs:
   title-and-description:


### PR DESCRIPTION
**[Jira ticket](https://taptapsend.atlassian.net/browse/PLAT-3773)**

## Summary
- Adds `permissions: pull-requests: write` to the reusable PR title lint workflow
- Fixes 403 "Resource not accessible by integration" error in downstream repos where the `jira-pr-action` tries to PATCH the PR title/description

## Test plan
- [ ] Verify a downstream repo PR triggers the workflow without a 403 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)